### PR TITLE
Fix meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
       title: 'My Custom Page Title',
       description: 'My custom page description',
       image: 'https://imagehosting.com/images/page_preview.jpg',
+      author: 'My Name',
     },
   },
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
     'about/people': 'NOTION_PAGE_ID',
   },
 
+  // Rewrite meta tags for specific pages
+  // Use the Notion page ID as the key
+  pageMetadata: {
+    'NOTION_PAGE_ID': {
+      title: 'My Custom Page Title',
+      description: 'My custom page description',
+      image: 'https://imagehosting.com/images/page_preview.jpg',
+    },
+  },
+
   // Subdomain redirects are optional
   // But it is recommended to have one for www
   subDomains: {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
   // URL to custom favicon.ico
   siteIcon: 'https://imagehosting.com/images/favicon.ico',
 
+  // Social media links, optional
+  twitterHandle: '@mytwitter',
+
   // Additional safety: avoid serving extraneous Notion content from your website
   // Use the value from your Notion settings => Workspace => Settings => Domain
   notionDomain: 'mydomain',

--- a/src/reverse-proxy-init.ts
+++ b/src/reverse-proxy-init.ts
@@ -10,6 +10,8 @@ export function initializeReverseProxy(siteConfigUser: NoteHostSiteConfig) {
     pageToSlug: {},
   }
 
+  siteConfig.pageMetadata = siteConfig.pageMetadata || {}
+
   siteConfig.fof = {
     page: siteConfig.fof?.page,
     slug: siteConfig.fof?.slug || '404',

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -50,7 +50,13 @@ export class MetaRewriter {
     }
 
     if (property === 'og:url' || name === 'twitter:url') {
-      element.setAttribute('content', 'https://' + domain + this.url.pathname)
+      if (this.isRootPage) {
+        element.setAttribute('content', `https://${domain}/`)
+      } else if (pageToSlug[page]) {
+        element.setAttribute('content', `https://${domain}/${pageToSlug[page]}`)
+      } else {
+        element.setAttribute('content', `https://${domain}/${page}`)
+      }
     }
 
     if (name === 'twitter:site') {

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -51,7 +51,7 @@ export class MetaRewriter {
     }
 
     if (property === 'og:url' || name === 'twitter:url') {
-      element.setAttribute('content', domain)
+      element.setAttribute('content', 'https://' + domain + this.url.pathname)
     }
 
     if (name === 'twitter:site') {

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -15,23 +15,29 @@ export class MetaRewriter {
   }
 
   element(element: Element) {
-    const { siteName, siteDescription, twitterHandle, siteImage, domain } = this.siteConfig
+    const { siteName, siteDescription, twitterHandle, siteImage, domain, pageToSlug } = this.siteConfig
+    const page = this.url.pathname.slice(-32)
     const property = element.getAttribute('property') ?? ''
     const name = element.getAttribute('name') ?? ''
-    let content = element.getAttribute('content') ?? ''
 
-    content = content.replace(' | Built with Notion', '')
-    content = content.replace(' | Notion', '')
     // console.log(
     //   `${this.url}: <${element.tagName} name="${name}" property="${property}">${content}</${element.tagName}>`,
     // )
 
     if (element.tagName === 'title') {
-      element.setInnerContent(content)
+      if (pageToSlug[page]) {
+        element.setInnerContent(`${siteName} | ${pageToSlug[page]}`)
+      } else {
+        element.setInnerContent(siteName)
+      }
     }
 
     if (property === 'og:title' || name === 'twitter:title') {
-      element.setAttribute('content', content)
+      if (pageToSlug[page]) {
+        element.setAttribute('content', `${siteName} | ${pageToSlug[page]}`)
+      } else {
+        element.setAttribute('content', siteName)
+      }
     }
 
 
@@ -40,14 +46,7 @@ export class MetaRewriter {
     }
 
     if (name === 'description' || property === 'og:description' || name === 'twitter:description') {
-      if (this.isRootPage) {
-        element.setAttribute('content', siteDescription)
-      } else {
-        element.setAttribute(
-          'content',
-          content.replace('Built with Notion, the all-in-one connected workspace with publishing capabilities.', ''),
-        )
-      }
+      element.setAttribute('content', siteDescription)
     }
 
     if (property === 'og:url' || name === 'twitter:url') {
@@ -55,15 +54,13 @@ export class MetaRewriter {
     }
 
     if (name === 'twitter:site') {
-      element.setAttribute('content', twitterHandle ?? '@NotionHQ')
+      element.setAttribute('content', twitterHandle ?? '')
     }
 
     if (siteImage) {
       if (property === 'og:image' || name === 'twitter:image') {
-        if (this.isRootPage) {
-          // console.log(`----- Image for url '${this.url.pathname}'`)
-          element.setAttribute('content', siteImage)
-        }
+        // console.log(`----- Image for url '${this.url.pathname}'`)
+        element.setAttribute('content', siteImage)
       }
     }
 

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -15,7 +15,7 @@ export class MetaRewriter {
   }
 
   element(element: Element) {
-    const { siteName, siteDescription, siteImage, domain } = this.siteConfig
+    const { siteName, siteDescription, twitterHandle, siteImage, domain } = this.siteConfig
     const property = element.getAttribute('property') ?? ''
     const name = element.getAttribute('name') ?? ''
     let content = element.getAttribute('content') ?? ''
@@ -34,6 +34,7 @@ export class MetaRewriter {
       element.setAttribute('content', content)
     }
 
+
     if (property === 'og:site_name' || name === 'article:author') {
       element.setAttribute('content', siteName)
     }
@@ -51,6 +52,10 @@ export class MetaRewriter {
 
     if (property === 'og:url' || name === 'twitter:url') {
       element.setAttribute('content', domain)
+    }
+
+    if (name === 'twitter:site') {
+      element.setAttribute('content', twitterHandle ?? '@NotionHQ')
     }
 
     if (siteImage) {

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -34,7 +34,6 @@ export class MetaRewriter {
       element.setAttribute('content', pageTitle)
     }
 
-
     if (property === 'og:site_name' || name === 'article:author') {
       element.setAttribute('content', siteName)
     }

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -15,7 +15,7 @@ export class MetaRewriter {
   }
 
   element(element: Element) {
-    const { siteName, siteDescription, twitterHandle, siteImage, domain, pageToSlug } = this.siteConfig
+    const { siteName, siteDescription, twitterHandle, siteImage, domain, pageToSlug, pageMetadata } = this.siteConfig
     const page = this.url.pathname.slice(-32)
     const property = element.getAttribute('property') ?? ''
     const name = element.getAttribute('name') ?? ''
@@ -25,19 +25,13 @@ export class MetaRewriter {
     // )
 
     if (element.tagName === 'title') {
-      if (pageToSlug[page]) {
-        element.setInnerContent(`${siteName} | ${pageToSlug[page]}`)
-      } else {
-        element.setInnerContent(siteName)
-      }
+      const pageTitle = pageMetadata[page]?.title ?? siteName
+      element.setInnerContent(pageTitle)
     }
 
     if (property === 'og:title' || name === 'twitter:title') {
-      if (pageToSlug[page]) {
-        element.setAttribute('content', `${siteName} | ${pageToSlug[page]}`)
-      } else {
-        element.setAttribute('content', siteName)
-      }
+      const pageTitle = pageMetadata[page]?.title ?? siteName
+      element.setAttribute('content', pageTitle)
     }
 
 
@@ -46,7 +40,8 @@ export class MetaRewriter {
     }
 
     if (name === 'description' || property === 'og:description' || name === 'twitter:description') {
-      element.setAttribute('content', siteDescription)
+      const pageDescription = pageMetadata[page]?.description ?? siteDescription
+      element.setAttribute('content', pageDescription)
     }
 
     if (property === 'og:url' || name === 'twitter:url') {
@@ -60,13 +55,20 @@ export class MetaRewriter {
     }
 
     if (name === 'twitter:site') {
-      element.setAttribute('content', twitterHandle ?? '')
+      if (twitterHandle) {
+        element.setAttribute('content', `${twitterHandle}`)
+      } else {
+        element.remove()
+      }
     }
 
-    if (siteImage) {
-      if (property === 'og:image' || name === 'twitter:image') {
-        // console.log(`----- Image for url '${this.url.pathname}'`)
-        element.setAttribute('content', siteImage)
+    if (property === 'og:image' || name === 'twitter:image') {
+      const pageImage = pageMetadata[page]?.image ?? siteImage
+      if (pageImage) {
+        // console.log(`----- Image for url '${this.url.pathname}: ${pageImage}'`)
+        element.setAttribute('content', pageImage)
+      } else {
+        element.remove()
       }
     }
 

--- a/src/rewriters/meta-rewriter.ts
+++ b/src/rewriters/meta-rewriter.ts
@@ -19,28 +19,38 @@ export class MetaRewriter {
     const page = this.url.pathname.slice(-32)
     const property = element.getAttribute('property') ?? ''
     const name = element.getAttribute('name') ?? ''
+    const content = element.getAttribute('content') ?? ''
 
     // console.log(
     //   `${this.url}: <${element.tagName} name="${name}" property="${property}">${content}</${element.tagName}>`,
     // )
 
     if (element.tagName === 'title') {
-      const pageTitle = pageMetadata[page]?.title ?? siteName
+      const pageTitle = pageMetadata[page]?.title ?? content.replace(' | Notion', '')
       element.setInnerContent(pageTitle)
     }
 
     if (property === 'og:title' || name === 'twitter:title') {
-      const pageTitle = pageMetadata[page]?.title ?? siteName
+      const pageTitle = pageMetadata[page]?.title ?? content.replace(' | Notion', '')
       element.setAttribute('content', pageTitle)
     }
 
-    if (property === 'og:site_name' || name === 'article:author') {
+    if (property === 'og:site_name') {
       element.setAttribute('content', siteName)
     }
 
+    if (name === 'article:author') {
+      const pageAuthor = pageMetadata[page]?.author ?? content
+      element.setAttribute('content', pageAuthor)
+    }
+
     if (name === 'description' || property === 'og:description' || name === 'twitter:description') {
-      const pageDescription = pageMetadata[page]?.description ?? siteDescription
-      element.setAttribute('content', pageDescription)
+      if (this.isRootPage) {
+        element.setAttribute('content', siteDescription)
+      } else {
+        const pageDescription = pageMetadata[page]?.description ?? content
+        element.setAttribute('content', pageDescription)
+      }
     }
 
     if (property === 'og:url' || name === 'twitter:url') {
@@ -62,12 +72,13 @@ export class MetaRewriter {
     }
 
     if (property === 'og:image' || name === 'twitter:image') {
-      const pageImage = pageMetadata[page]?.image ?? siteImage
-      if (pageImage) {
+      if (this.isRootPage && siteImage) {
+        // console.log(`----- Image for url '${this.url.pathname}: ${siteImage}'`)
+        element.setAttribute('content', siteImage)
+      } else {
+        const pageImage = pageMetadata[page]?.image ?? content
         // console.log(`----- Image for url '${this.url.pathname}: ${pageImage}'`)
         element.setAttribute('content', pageImage)
-      } else {
-        element.remove()
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,9 +75,9 @@ export interface NoteHostNotionSlugConfig {
 // Overrides site-level metadata
 export interface NoteHostSiteConfigPageMetadata {
   // <title>, og:title and twitter:title
-  title: string
+  title?: string
   // description, og:description and twitter:description
-  description: string
+  description?: string
   // og:image and twitter:image
   image?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,12 @@ export interface NoteHostSiteConfigFull {
   // Mapping from slug to page ID
   slugToPage: Record<string, string>
   notionSlugToPage?: NoteHostNotionSlugConfig
+  pageMetadata?: Record<string, NoteHostSiteConfigPageMetadata>
 
   // SEO metadata
-  // og:site_name, article:author
+  // title, og:site_name, article:author
   siteName: string
-  // og:description, twitter:description
+  // description, og:description, twitter:description
   siteDescription: string
   // twitter:site, twitter:creator
   twitterHandle?: string
@@ -68,4 +69,15 @@ export interface NoteHostNotionSlugConfig {
 
   // TODO: sync this DB to firebase via notesync
   // and save values to slugs KV on webhook from notesync
+}
+
+// Page SEO metadata
+// Overrides site-level metadata
+export interface NoteHostSiteConfigPageMetadata {
+  // <title>, og:title and twitter:title
+  title: string
+  // description, og:description and twitter:description
+  description: string
+  // og:image and twitter:image
+  image?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,4 +80,6 @@ export interface NoteHostSiteConfigPageMetadata {
   description?: string
   // og:image and twitter:image
   image?: string
+  // article:author
+  author?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface NoteHostSiteConfigFull {
   siteName: string
   // og:description, twitter:description
   siteDescription: string
+  // twitter:site, twitter:creator
+  twitterHandle?: string
   // og:image, twitter:image
   siteImage?: string
 

--- a/templates/default/src/site-config.ts
+++ b/templates/default/src/site-config.ts
@@ -13,6 +13,9 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
   siteDescription: '<%= siteDescription %>',
   siteImage: '<%= siteImage %>',
 
+  // Twitter handle, optional
+  // twitterHandle: '',
+  
   // URL to custom favicon.ico
   // siteIcon: '',
 

--- a/templates/default/src/site-config.ts
+++ b/templates/default/src/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
 
   // Twitter handle, optional
   // twitterHandle: '',
-  
+
   // URL to custom favicon.ico
   // siteIcon: '',
 
@@ -32,6 +32,16 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
     // Hint: you can use '/' in slug name to create subpages
     'about/people': 'NOTION_PAGE_ID',
   },
+
+  // Rewrite meta tags for specific pages
+  // Use the Notion page ID as the key
+  // pageMetadata: {
+  //   'NOTION_PAGE_ID': {
+  //     title: 'My Custom Page Title',
+  //     description: 'My custom page description',
+  //     image: 'https://imagehosting.com/images/page_preview.jpg',
+  //   },
+  // },
 
   // Subdomain redirects are optional
   // But it is recommended to have one for www

--- a/templates/default/src/site-config.ts
+++ b/templates/default/src/site-config.ts
@@ -40,6 +40,7 @@ export const SITE_CONFIG: NoteHostSiteConfig = {
   //     title: 'My Custom Page Title',
   //     description: 'My custom page description',
   //     image: 'https://imagehosting.com/images/page_preview.jpg',
+  //     author: 'My Name',
   //   },
   // },
 


### PR DESCRIPTION
Fixes #36

With this fix users can set their X / Twitter handle for the website, as well as custom metadata per page e.g.:

```typescript
// Rewrite meta tags for specific pages
// Use the Notion page ID as the key
pageMetadata: {
  'NOTION_PAGE_ID': {
    title: 'My Custom Page Title',
    description: 'My custom page description',
    image: 'https://imagehosting.com/images/page_preview.jpg',
  },
},
```

It also sets `og:url` and `twitter:url` to the slug if one is available, using pageId as a fallback.

With this change I can get my proxied page properly indexed on search engines.

